### PR TITLE
Require perl version can be 5.6.0

### DIFF
--- a/lib/Test/Requires.pm
+++ b/lib/Test/Requires.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 our $VERSION = '0.05';
 use base 'Test::Builder::Module';
-use 5.008000;
+use 5.006000;
 
 sub import {
     my $class = shift;


### PR DESCRIPTION
Hi,

I need this module to test Mouse, but it requires 5.8.0. I have tested it on 5.6.2 and got all the test passed.
Please set required perl version to 5.6.0!
