### PR TITLE
Test::Requires "Missing::Module" bails out rather than skips if $ENV{RELEASE_TESTING} is true.

### DIFF
--- a/lib/Test/Requires.pm
+++ b/lib/Test/Requires.pm
@@ -58,11 +58,17 @@ sub test_requires {
                 exit 0;
             }
         };
+        
+        my $msg = "$e";
         if ( $e =~ /^Can't locate/ ) {
-            $skip_all->("Test requires module '$mod' but it's not found");
+            $msg = "Test requires module '$mod' but it's not found";
+        }
+        
+        if ($ENV{RELEASE_TESTING}) {
+            __PACKAGE__->builder->BAIL_OUT($msg);
         }
         else {
-            $skip_all->("$e");
+            $skip_all->($msg);
         }
     }
 }
@@ -123,6 +129,11 @@ Tokuhiro Matsuno E<lt>tokuhirom @*(#RJKLFHFSDLJF gmail.comE<gt>
     miyagawa++ # original code from t/TestPlagger.pm
     tomyhero++ # reported issue related older test::builder
     tobyink++ # documented that Test::Requires "5.010" works
+
+=head1 ENVIRONMENT
+
+If the C<< RELEASE_TESTING >> environment variable is true, then instead
+of skipping tests, Test::Requires bails out.
 
 =head1 SEE ALSO
 

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -1,3 +1,4 @@
+BEGIN { $ENV{RELEASE_TESTING} = 0 };
 use strict;
 use warnings;
 use Test::More tests => 10;

--- a/t/02_no_plan.t
+++ b/t/02_no_plan.t
@@ -1,3 +1,4 @@
+BEGIN { $ENV{RELEASE_TESTING} = 0 };
 use strict;
 use warnings;
 use Test::More 'no_plan';

--- a/t/03_import_hashref.t
+++ b/t/03_import_hashref.t
@@ -1,3 +1,4 @@
+BEGIN { $ENV{RELEASE_TESTING} = 0 };
 use strict;
 use warnings;
 use Test::More;

--- a/t/04_import_array.t
+++ b/t/04_import_array.t
@@ -1,3 +1,4 @@
+BEGIN { $ENV{RELEASE_TESTING} = 0 };
 use strict;
 use warnings;
 use Test::More;

--- a/t/06_perlver.t
+++ b/t/06_perlver.t
@@ -1,3 +1,4 @@
+BEGIN { $ENV{RELEASE_TESTING} = 0 };
 use strict;
 use warnings;
 use Test::More 'no_plan';


### PR DESCRIPTION
For RT#84737
