### PR TITLE
Requires 5.8.1

### DIFF
--- a/lib/Test/Requires.pm
+++ b/lib/Test/Requires.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 our $VERSION = '0.08';
 use base 'Test::Builder::Module';
-use 5.006000;
+use 5.008001;
 
 sub import {
     my $class = shift;


### PR DESCRIPTION
This somehow addresses #11 by eliminating the confusion. It might very well be not what that ticket wants, but at least it becomes more explicit and removes the metadata inconsistency.

My strong argument is here: This module requires Test::More 0.61 or later, which is core since perl 5.8.8. If one wants to support 5.6, requiring this module to require a higher version of Test::More sounds something they want to avoid altogether.

And the functionality of this module isn't really critical at all.